### PR TITLE
Make file search consistently case sensitive or insensitive

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,12 @@ If `-t` is specified then after the application finishes, with or without error,
 
 If `-a` is specified then warnings and errors will be output to the console using ANSI colors (this is the default). `-na` will cause all console output to be in the default color.
 
+* `-c` and `-nc`
+
+By default (and also when `-nc` is used) the applications will perform a case-insensitive file search when trying to locate an existing file; that is, an existing `foobar.mac` will be a match when searching for `FOOBAR.MAC`. The `-c` option will force the search to be case-sensitive instead.
+
+This options pair and the described search behavior were introduced in v1.1. In v1.0 file search was always case-insensitive in Windows and always case-sensitive in Linux and macOS.
+
 * `-8` and `-n8` (only for M80)
 
 M80 doesn't support 8 bit characters by default: all characters read from the source files will have their MSB zeroed before being processed. This will likely cause assembly errors if the source contains strings with 8 bit characters (encoded in some old extended character set), so the `-8` switch is offered to suppress this MSB zeroing of source bytes. `-n8` will keep the original MSB-zeroing behavior (this is the default).

--- a/Shared/AssemblyInfo.cs
+++ b/Shared/AssemblyInfo.cs
@@ -1,4 +1,4 @@
 using System.Reflection;
 
-[assembly: AssemblyVersion("1.0")]
-[assembly: AssemblyFileVersion("1.0")]
+[assembly: AssemblyVersion("1.1")]
+[assembly: AssemblyFileVersion("1.1")]

--- a/Shared/ProgramRunner.cs
+++ b/Shared/ProgramRunner.cs
@@ -284,7 +284,7 @@ By Konamiman, 2020");
 @$"https://github.com/Konamiman/M80dotNet
 
 Usage: {ProgramName} [-w <working dir>] [-p <path>[,<path>...]] 
-           [-i|-ni] [-b|-nb] [-t|-nt] [-a|-na] {extraCmd}<command line for {ProgramName}>
+           [-i|-ni] [-b|-nb] [-t|-nt] [-a|-na] [-c|-nc] {extraCmd}<command line for {ProgramName}>
 
 -w: Set working directory (default: current working directory)
 -p: Additional paths to search for files (comma separated list)

--- a/Shared/ProgramRunner.cs
+++ b/Shared/ProgramRunner.cs
@@ -30,6 +30,8 @@ namespace Konamiman.M80dotNet
 
         private bool PrintInColor;
 
+        private bool CaseSensitiveFileSearch;
+
         // Yes I know, I should use subclassing for that stuff.
         // But this is a small project, so let's just move on, mkay?
         private readonly bool IsM80;
@@ -66,7 +68,7 @@ namespace Konamiman.M80dotNet
                 }
             }
 
-            z80 = new Z80Processor(WorkingDirectory, PrintInColor, ConvertCrToLf, AdditionalSearchPaths);
+            z80 = new Z80Processor(WorkingDirectory, PrintInColor, ConvertCrToLf, AdditionalSearchPaths, CaseSensitiveFileSearch);
 
             z80.Memory[6] = 0xFF; //End of TPA
             z80.Memory[7] = 0xFF;
@@ -139,6 +141,7 @@ namespace Konamiman.M80dotNet
             Allow8Bit = false;
             ConvertCrToLf = IsM80;
             AdditionalSearchPaths = new string[0];
+            CaseSensitiveFileSearch = false;
 
             var envCommandLine = Environment.GetEnvironmentVariable($"X80_COMMAND_LINE") ?? "";
             envCommandLine += " " + (Environment.GetEnvironmentVariable($"{ProgramName}_COMMAND_LINE") ?? "");
@@ -222,6 +225,14 @@ namespace Konamiman.M80dotNet
                 {
                     ConvertCrToLf = false;
                 }
+                else if (args[i] == "-c")
+                {
+                    CaseSensitiveFileSearch = true;
+                }
+                else if (args[i] == "-nc")
+                {
+                    CaseSensitiveFileSearch = false;
+                }
                 else
                 {
                     ShowHelpAndExit();
@@ -286,6 +297,8 @@ Usage: {ProgramName} [-w <working dir>] [-p <path>[,<path>...]]
 -nt: Don't measure execution time (default)
 -a: Print in console using ANSI colors (default)
 -na: Don't print in console using ANSI colors
+-c: Do case-sensitive file searches
+-nc: Do case-insensitive file searches (default)
 {extra}
 Command line for {ProgramName} is required when not running in interactive move.
 

--- a/Shared/Z80 and CPM/Z80Processor.cs
+++ b/Shared/Z80 and CPM/Z80Processor.cs
@@ -20,7 +20,7 @@ namespace Konamiman.M80dotNet
     {
         public byte[] Memory { get; private set; } = new byte[65536];
 
-        public Z80Processor(string workingDirectory, bool printInColor, bool convertCrToLf, string[] additionalSearchPaths)
+        public Z80Processor(string workingDirectory, bool printInColor, bool convertCrToLf, string[] additionalSearchPaths, bool caseSensitiveFileSearch)
         {
             this.workingDirectory = Path.GetFullPath(workingDirectory);
             InitializeInstructionTables();
@@ -33,6 +33,11 @@ namespace Konamiman.M80dotNet
             var searchPaths = additionalSearchPaths.Select(p => Path.GetFullPath(Path.Combine(workingDirectory, p))).ToList();
             searchPaths.Insert(0, workingDirectory);
             this.searchPaths = searchPaths.ToArray();
+
+            this.fileSearchEnumerationOptions = new EnumerationOptions 
+            { 
+                MatchCasing = caseSensitiveFileSearch ? MatchCasing.CaseSensitive : MatchCasing.CaseInsensitive 
+            };
         }
 
         public void Start(ushort address = 0)


### PR DESCRIPTION
In v1.0 the applications search for existing files in a case-insensitive way in Windows, and in a case-sensitive way in Linux/OSX. With this change:

- File search is now case-insensitive by default, regardless of the underlying OS.
- A `-c` option is added to make it case-sensitive, again, in an OS-independent way. `-nc` also exists to restore the default behavior.